### PR TITLE
Skip arrays to avoid tons message in the logs

### DIFF
--- a/core/components/seosuite/model/seosuite/seosuite.class.php
+++ b/core/components/seosuite/model/seosuite/seosuite.class.php
@@ -776,7 +776,9 @@ class SeoSuite
         $unProcessedValue   = $value;
 
         if (!empty($value)) {
-            $data = array_map('trim', $fields);
+            $data = array_map(function ($value) {
+                return is_string($value) ? trim($value) : $value;
+            }, $fields);
 
             if (empty($data['longtitle'])) {
                 $data['longtitle'] = $data['pagetitle'];


### PR DESCRIPTION
It fixes the issue when a resource can contain additional properties as an array (for example, when ContentBlocks used), and calling function trim over array produces tons message in the log.

The new one to the proper branch.