### PR TITLE
Fix 500 error when no resource is found

### DIFF
--- a/core/components/seosuite/model/seosuite/snippets/seosuitesnippets.class.php
+++ b/core/components/seosuite/model/seosuite/snippets/seosuitesnippets.class.php
@@ -35,9 +35,9 @@ class SeoSuiteSnippets extends SeoSuite
             ]
         ];
 
-        $ssResource = $this->modx->getObject('SeoSuiteResource', [
-            'resource_id' => $id
-        ]);
+        if (!$ssResource = $this->modx->getObject('SeoSuiteResource', ['resource_id' => $id])) {
+            return false;   
+        }
 
         $canonicalUrl = $this->modx->makeUrl($id, null, null, 'full');
         if ($ssResource) {


### PR DESCRIPTION
Fix 500 error when no resource is found, for instance when a context has site_status 1 and your not allowed to view the context.