### PR TITLE
fix empty [[!+ss_meta.keywords]]

### DIFF
--- a/core/components/seosuite/model/seosuite/snippets/seosuitesnippets.class.php
+++ b/core/components/seosuite/model/seosuite/snippets/seosuitesnippets.class.php
@@ -50,7 +50,7 @@ class SeoSuiteSnippets extends SeoSuite
                 'tpl'   => $tpl
             ];
 
-            $meta['keywords'] = [
+            $meta['_keywords'] = [
                 'name'  => 'keywords',
                 'value' => $ssResource->get('keywords'),
                 'tpl'   => $tpl

--- a/core/components/seosuite/model/seosuite/snippets/seosuitesnippets.class.php
+++ b/core/components/seosuite/model/seosuite/snippets/seosuitesnippets.class.php
@@ -50,6 +50,12 @@ class SeoSuiteSnippets extends SeoSuite
                 'tpl'   => $tpl
             ];
 
+            $meta['keywords'] = [
+                'name'  => 'keywords',
+                'value' => $ssResource->get('keywords'),
+                'tpl'   => $tpl
+            ];
+
             if ($ssResource->get('canonical') && !empty($ssResource->get('canonical_uri'))) {
                 $canonicalUrl = rtrim($this->modx->makeUrl($this->modx->getOption('site_start'), null, null, 'full'), '/') . '/' . ltrim($ssResource->get('canonical_uri'), '/');
             }


### PR DESCRIPTION
Right now when I add [[!+ss_meta.keywords]] to template - I get nothing. 