### PR TITLE
Fix creating redirect when sorting within same parent

### DIFF
--- a/core/components/seosuite/model/seosuite/plugins/seosuiteresourceplugin.class.php
+++ b/core/components/seosuite/model/seosuite/plugins/seosuiteresourceplugin.class.php
@@ -268,7 +268,7 @@ class SeoSuiteResourcePlugin extends SeoSuitePlugin
 
         $oldResource = $this->modx->getObject('modResource', $resource);
         $modResource = $this->modx->getObject('modResource', $resource);
-        if ($oldResource && $modResource) {
+        if ($oldResource && $modResource && $target !== $oldResource->get('parent')) {
             $modResource->set('parent', $target);
             $modResource->set('uri', '');
 


### PR DESCRIPTION
When a resource is sorted within the same parent a redirect is created with the same Uri the resource has.
Which in return will create a lot of cluttering in the database.