### PR TITLE
Render canonical as link tag not as meta tag

### DIFF
--- a/core/components/seosuite/model/seosuite/snippets/seosuitesnippets.class.php
+++ b/core/components/seosuite/model/seosuite/snippets/seosuitesnippets.class.php
@@ -77,7 +77,7 @@ class SeoSuiteSnippets extends SeoSuite
         $meta['_canonical'] = [
             'name'  => 'canonical',
             'value' => $canonicalUrl,
-            'tpl'   => $tpl
+            'tpl'   => $tplLink
         ];
 
         if (!empty($this->config['tab_social']['default_og_image'])) {


### PR DESCRIPTION
Adresses issue #43
The canonical deklaration should be a link tag not a meta tag

Source: https://developers.google.com/search/docs/advanced/crawling/consolidate-duplicate-urls#rel-canonical-link-method