### PR TITLE
 fix: render meta tags on resources created before seosuite was installed

### DIFF
--- a/core/components/seosuite/model/seosuite/snippets/seosuitesnippets.class.php
+++ b/core/components/seosuite/model/seosuite/snippets/seosuitesnippets.class.php
@@ -39,9 +39,7 @@ class SeoSuiteSnippets extends SeoSuite
             ]
         ];
 
-        if (!$ssResource = $this->modx->getObject('SeoSuiteResource', ['resource_id' => $id])) {
-            return false;   
-        }
+        $ssResource = $this->modx->getObject('SeoSuiteResource', ['resource_id' => $id]);
 
         $canonicalUrl = $this->modx->makeUrl($id, null, null, 'full');
         if ($ssResource) {


### PR DESCRIPTION
SeoSuiteResource does not exist for resources before they are saved. If you install the plugin on an existing site, the meta tags will not be rendered.