### PR TITLE
Fixed error on PHP 8

### DIFF
--- a/core/components/seosuite/src/Snippets/Meta.php
+++ b/core/components/seosuite/src/Snippets/Meta.php
@@ -133,7 +133,7 @@ class Meta extends Base
             $meta['_alternates'] = [
                 'name'  => 'alternates',
                 'value' => $this->modx->getChunk($tplAlternateWrapper, [
-                    'output' => implode($values, PHP_EOL)
+                    'output' => implode(PHP_EOL, $values)
                 ])
             ];
         }


### PR DESCRIPTION
Fixed error on PHP 8 because legacy signature on implode()-Function is removed as of PHP 8.0.0. Fixes #59