### PR TITLE
Improved getting url to support special chars

### DIFF
--- a/core/components/seosuite/src/Plugins/Redirects.php
+++ b/core/components/seosuite/src/Plugins/Redirects.php
@@ -9,11 +9,10 @@ class Redirects extends Base
 {
     /**
      * @access public.
-     * @return Mixed.
      */
     public function onPageNotFound()
     {
-        $request = urldecode(trim($_GET[$this->modx->getOption('request_param_alias', null, 'q')], '/'));
+        $request = urldecode(trim($_REQUEST[$this->modx->getOption('request_param_alias', null, 'q')], '/'));
 
         if (!empty($request)) {
             $this->redirect($request);


### PR DESCRIPTION
We were able to enter urls with special character to manager like 
`/products/Laadplatform-Dranghekken-%7C-3350-%7C-Incl.-dranghekken.html`

It would be decoded and stored as `/products/Laadplatform-Dranghekken-|-3350-|-Incl.-dranghekken.html`

But when you navigate to this address, redirect would not work, because it was retrieved from `$_GET` instead `$_REQUEST`.

![Screenshot 2023-03-10 at 14 38 52](https://user-images.githubusercontent.com/1257284/224253678-94351c3a-ae9f-446d-b353-f6d5aef671d5.png)

Now it is fixed.

