### PR TITLE
Replace htmlentities by htmlspecialchars in renderMetaValue method

### DIFF
--- a/core/components/seosuite/src/SeoSuite.php
+++ b/core/components/seosuite/src/SeoSuite.php
@@ -804,8 +804,8 @@ class SeoSuite
         }
 
         return [
-            'processed'     => htmlentities($processedValue),
-            'unprocessed'   => htmlentities($unProcessedValue)
+            'processed'     => htmlspecialchars($processedValue),
+            'unprocessed'   => htmlspecialchars($unProcessedValue)
         ];
     }
 


### PR DESCRIPTION
SEOSuite replace unicode symbols like "à","è", etc in page title and description by HTML entities. This behaviour  is incorrect for Google.

Method `renderMetaValue` use `htmlentities` function for replacing quotes for HTML was not broken.

I propose to replace this function by `htmlspecialchars` - so HTML will not broken, but unicode symbols will be correct.