### PR TITLE
Language tweaks for consistency and grammar

### DIFF
--- a/core/components/seosuite/lexicon/en/tab_seo.inc.php
+++ b/core/components/seosuite/lexicon/en/tab_seo.inc.php
@@ -6,10 +6,10 @@
  * Copyright 2019 by Sterc <modx@sterc.com>
  */
 
-$_lang['seosuite.tab_seo']                                  = 'Search engine';
+$_lang['seosuite.tab_seo']                                  = 'Search Engine';
 $_lang['seosuite.tab_seo.tab_searchable']                   = 'Findability';
 $_lang['seosuite.tab_seo.tab_sitemap']                      = 'Sitemap';
-$_lang['seosuite.tab_seo.tab_urls']                         = 'URL\'s';
+$_lang['seosuite.tab_seo.tab_urls']                         = 'URLs';
 
 $_lang['seosuite.tab_seo.label_index']                      = 'Index page';
 $_lang['seosuite.tab_seo.label_index_desc']                 = 'If "Yes" is selected then all search engines will be able to index the page. It is better to prevent irrelevant pages from being index by search engines. Example of these pages are: disclaimer, general conditions and the privacy policy.';

--- a/core/components/seosuite/lexicon/en/tab_social.inc.php
+++ b/core/components/seosuite/lexicon/en/tab_social.inc.php
@@ -6,20 +6,21 @@
  * Copyright 2019 by Sterc <modx@sterc.com>
  */
 
-$_lang['seosuite.tab_social']                                   = 'Social';
-$_lang['seosuite.tab_social.tab_facebook']                      = 'Facebook';
+$_lang['seosuite.tab_social']                                   = 'Sharing';
+$_lang['seosuite.tab_social.tab_facebook']                      = 'Open Graph';
 $_lang['seosuite.tab_social.tab_twitter']                       = 'Twitter';
 
-$_lang['seosuite.tab_social.label_og_title']                    = 'Facebook title';
-$_lang['seosuite.tab_social.label_og_title_desc']               = 'The title of the page on Facebook.';
-$_lang['seosuite.tab_social.label_og_description']              = 'Facebook description';
-$_lang['seosuite.tab_social.label_og_description_desc']         = 'The description of the page on Facebook.';
-$_lang['seosuite.tab_social.label_og_image']                    = 'Facebook image';
-$_lang['seosuite.tab_social.label_og_image_desc']               = 'The image of the page on Facebook, the beste format is 1200 x 630 pixels.';
-$_lang['seosuite.tab_social.label_og_image_alt']                = 'Facebook image title';
-$_lang['seosuite.tab_social.label_og_image_alt_desc']           = 'The image title of the page on Facebook.';
-$_lang['seosuite.tab_social.label_og_type']                     = 'Facebook type';
-$_lang['seosuite.tab_social.label_og_type_desc']                = 'The page type on Facebook.';
+$_lang['seosuite.tab_social.label_og_title']                    = 'Title (og:title)';
+$_lang['seosuite.tab_social.label_og_title_desc']               = 'REQUIRED: The title of the page as it should appear within the graph, e.g., for Facebook shares.';
+$_lang['seosuite.tab_social.label_og_description']              = 'Description (og:description)';
+$_lang['seosuite.tab_social.label_og_description_desc']         = 'The page description of the page on Facebook.';
+$_lang['seosuite.tab_social.label_og_image']                    = 'Image (og:image)';
+$_lang['seosuite.tab_social.label_og_image_desc']               = 'REQUIRED: An image URL which should represent your object within the graph. The best format is 1200 x 630 pixels.';
+$_lang['seosuite.tab_social.label_og_image_alt']                = 'Image alt title (og:image:alt)';
+$_lang['seosuite.tab_social.label_og_image_alt_desc']           = 'A description of what is in the image (not a caption).';
+$_lang['seosuite.tab_social.label_og_type']                     = 'Type (og:type)';
+$_lang['seosuite.tab_social.label_og_type_desc']                = 'REQUIRED: The type of your object, e.g., “website”. Depending on the type you specify, other properties may also be required.
+.';
 
 $_lang['seosuite.tab_social.label_twitter_title']               = 'Twitter title';
 $_lang['seosuite.tab_social.label_twitter_title_desc']          = 'The title of the page on Twitter.';


### PR DESCRIPTION
URL’s should not acutally be possessive—it should be plural.

"Search engine" (lowercase E) always stood out on the tab as the only non-titlecase word.