### PR TITLE
Fix schema

### DIFF
--- a/core/components/seosuite/schema/seosuite.mysql.schema.xml
+++ b/core/components/seosuite/schema/seosuite.mysql.schema.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<model package="Sterc\SeoSuite\Model\" baseClass="xPDO\Om\xPDOSimpleObject" platform="mysql" defaultEngine="InnoDB" phpdoc-package="seosuite" version="0.2">
-    <object class="SeoSuiteSocial" table="seosuite_social" extends="xPDOSimpleObject">
+<model package="Sterc\SeoSuite\Model\" baseClass="xPDO\Om\xPDOSimpleObject" platform="mysql" defaultEngine="InnoDB" phpdoc-package="seosuite" version="3.0">
+    <object class="SeoSuiteSocial" table="seosuite_social" extends="xPDO\Om\xPDOSimpleObject">
         <field key="resource_id" dbtype="integer" precision="11" phptype="int" null="false" default="" index="index"/>
         <field key="og_title" dbtype="varchar" precision="255" phptype="string" null="false" default=""/>
         <field key="og_description" dbtype="varchar" precision="255" phptype="string" null="false" default=""/>
@@ -16,32 +16,32 @@
         <field key="inherit_facebook" dbtype="int" precision="1" phptype="integer" null="true" default="1"/>
         <field key="editedon" dbtype="timestamp" phptype="timestamp" null="true" default="NULL" attributes="ON UPDATE CURRENT_TIMESTAMP" />
 
-        <aggregate alias="Resource" class="modResource" local="bundle" foreign="id" cardinality="one" owner="foreign" />
+        <aggregate alias="Resource" class="MODX\Revolution\modResource" local="bundle" foreign="id" cardinality="one" owner="foreign" />
 
         <index alias="resource_id" name="resource_id" primary="false" unique="false" type="BTREE">
             <column key="resource_id" length="" collation="A" null="false" />
         </index>
     </object>
 
-    <object class="SeoSuiteUrl" table="seosuite_url" extends="xPDOSimpleObject">
+    <object class="SeoSuiteUrl" table="seosuite_url" extends="xPDO\Om\xPDOSimpleObject">
         <field key="context_key" dbtype="varchar" precision="100" phptype="string" null="false" default="" index="index"/>
         <field key="url" dbtype="varchar" precision="2000" phptype="string" null="false" default="" index="index"/>
         <field key="suggestions" dbtype="text" phptype="json" null="true" />
         <field key="visits" dbtype="integer" precision="11" phptype="int" null="false" default=""/>
-        <field key="last_visit" dbtype="timestamp" phptype="timestamp" null="true" default="0000-00-00 00:00:00"/>
+        <field key="last_visit" dbtype="timestamp" phptype="timestamp" null="true" />
         <field key="createdon" dbtype="timestamp" phptype="timestamp" null="false" default="CURRENT_TIMESTAMP"/>
 
-        <aggregate alias="Context" class="modContext" local="bundle" foreign="id" cardinality="one" owner="foreign" />
+        <aggregate alias="Context" class="MODX\Revolution\modContext" local="bundle" foreign="id" cardinality="one" owner="foreign" />
 
         <index alias="context_key" name="context_key" primary="false" unique="false" type="BTREE">
-            <column key="context_key" length="" collation="A" null="false"></column>
+            <column key="context_key" length="" collation="A" null="false" />
         </index>
         <index alias="url" name="url" primary="false" unique="false" type="BTREE">
-            <column key="url" length="" collation="A" null="false" />
+            <column key="url" length="191" collation="A" null="false" />
         </index>
     </object>
 
-    <object class="SeoSuiteResource" table="seosuite_resource" extends="xPDOSimpleObject">
+    <object class="SeoSuiteResource" table="seosuite_resource" extends="xPDO\Om\xPDOSimpleObject">
         <field key="keywords" dbtype="text" phptype="string" null="true" default="" />
         <field key="resource_id" dbtype="integer" precision="10" phptype="int" null="false" default="" index="index"/>
         <field key="use_default_meta" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="1" />
@@ -56,7 +56,7 @@
         <field key="canonical_uri" dbtype="varchar" precision="255" phptype="string" null="false" default=""/>
         <field key="editedon" dbtype="timestamp" phptype="timestamp" null="true" default="NULL" attributes="ON UPDATE CURRENT_TIMESTAMP" />
 
-        <aggregate alias="Resource" class="modResource" local="bundle" foreign="id" cardinality="one" owner="foreign" />
+        <aggregate alias="Resource" class="MODX\Revolution\modResource" local="bundle" foreign="id" cardinality="one" owner="foreign" />
 
         <index alias="resource_id" name="resource_id" primary="false" unique="false" type="BTREE">
             <column key="resource_id" length="" collation="A" null="false" />
@@ -72,7 +72,7 @@
         </index>
     </object>
 
-    <object class="SeoSuiteRedirect" table="seosuite_redirect" extends="xPDOSimpleObject">
+    <object class="SeoSuiteRedirect" table="seosuite_redirect" extends="xPDO\Om\xPDOSimpleObject">
         <field key="context_key" dbtype="varchar" precision="100" phptype="string" null="false" default="" index="index"/>
         <field key="resource_id" dbtype="integer" precision="10" phptype="int" null="false" default="" index="index"/>
         <field key="old_url" dbtype="varchar" precision="255" phptype="string" null="false" default="" index="index"/>
@@ -80,11 +80,11 @@
         <field key="redirect_type" dbtype="varchar" precision="75" phptype="string" null="false" default="" />
         <field key="active" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="1" index="index"/>
         <field key="visits" dbtype="integer" precision="11" phptype="int" null="false" default=""/>
-        <field key="last_visit" dbtype="timestamp" phptype="timestamp" null="true" default="0000-00-00 00:00:00"/>
+        <field key="last_visit" dbtype="timestamp" phptype="timestamp" null="true" />
         <field key="editedon" dbtype="timestamp" phptype="timestamp" null="true" default="NULL" attributes="ON UPDATE CURRENT_TIMESTAMP" />
 
-        <aggregate alias="Context" class="modContext" local="bundle" foreign="id" cardinality="one" owner="foreign" />
-        <aggregate alias="Resource" class="modResource" local="bundle" foreign="id" cardinality="one" owner="foreign" />
+        <aggregate alias="Context" class="MODX\Revolution\modContext" local="bundle" foreign="id" cardinality="one" owner="foreign" />
+        <aggregate alias="Resource" class="MODX\Revolution\modResource" local="bundle" foreign="id" cardinality="one" owner="foreign" />
 
         <index alias="context_key" name="context_key" primary="false" unique="false" type="BTREE">
             <column key="context_key" length="" collation="A" null="false"/>
@@ -93,7 +93,7 @@
             <column key="resource_id" length="" collation="A" null="false" />
         </index>
         <index alias="old_url" name="old_url" primary="false" unique="false" type="BTREE">
-            <column key="old_url" length="" collation="A" null="false"/>
+            <column key="old_url" length="191" collation="A" null="false"/>
         </index>
         <index alias="active" name="active" primary="false" unique="false" type="BTREE">
             <column key="active" length="" collation="A" null="false" />

--- a/core/components/seosuite/src/Model/SeoSuiteRedirect.php
+++ b/core/components/seosuite/src/Model/SeoSuiteRedirect.php
@@ -19,7 +19,7 @@ use MODX\Revolution\modResource;
  *
  * @package Sterc\SeoSuite\Model
  */
-class SeoSuiteRedirect extends \xPDOSimpleObject
+class SeoSuiteRedirect extends \xPDO\Om\xPDOSimpleObject
 {
     /**
      * @access public.

--- a/core/components/seosuite/src/Model/SeoSuiteResource.php
+++ b/core/components/seosuite/src/Model/SeoSuiteResource.php
@@ -22,6 +22,6 @@ use xPDO\xPDO;
  *
  * @package Sterc\SeoSuite\Model
  */
-class SeoSuiteResource extends \xPDOSimpleObject
+class SeoSuiteResource extends \xPDO\Om\xPDOSimpleObject
 {
 }

--- a/core/components/seosuite/src/Model/SeoSuiteSocial.php
+++ b/core/components/seosuite/src/Model/SeoSuiteSocial.php
@@ -23,7 +23,7 @@ use xPDO\xPDO;
  *
  * @package Sterc\SeoSuite\Model
  */
-class SeoSuiteSocial extends \xPDOSimpleObject
+class SeoSuiteSocial extends \xPDO\Om\xPDOSimpleObject
 {
     const INHERIT_FIELD = [
         'twitter_title'         => 'og_title',

--- a/core/components/seosuite/src/Model/SeoSuiteUrl.php
+++ b/core/components/seosuite/src/Model/SeoSuiteUrl.php
@@ -17,7 +17,7 @@ use xPDO\Om\xPDOQuery;
  *
  * @package Sterc\SeoSuite\Model
  */
-class SeoSuiteUrl extends \xPDOSimpleObject
+class SeoSuiteUrl extends \xPDO\Om\xPDOSimpleObject
 {
     /**
      * @access public.

--- a/core/components/seosuite/src/Model/metadata.mysql.php
+++ b/core/components/seosuite/src/Model/metadata.mysql.php
@@ -1,10 +1,16 @@
 <?php
 $xpdo_meta_map = array (
-    'xPDO\\Om\\xPDOSimpleObject' =>
+    'version' => '3.0',
+    'namespace' => 'Sterc\\SeoSuite\\Model',
+    'namespacePrefix' => 'Sterc\\SeoSuite',
+    'class_map' => 
     array (
-        0 => 'Sterc\\SeoSuite\\Model\\SeoSuiteSocial',
-        1 => 'Sterc\\SeoSuite\\Model\\SeoSuiteUrl',
-        2 => 'Sterc\\SeoSuite\\Model\\SeoSuiteResource',
-        3 => 'Sterc\\SeoSuite\\Model\\SeoSuiteRedirect',
+        'xPDO\\Om\\xPDOSimpleObject' => 
+        array (
+            0 => 'Sterc\\SeoSuite\\Model\\SeoSuiteSocial',
+            1 => 'Sterc\\SeoSuite\\Model\\SeoSuiteUrl',
+            2 => 'Sterc\\SeoSuite\\Model\\SeoSuiteResource',
+            3 => 'Sterc\\SeoSuite\\Model\\SeoSuiteRedirect',
+        ),
     ),
 );

--- a/core/components/seosuite/src/Model/mysql/SeoSuiteRedirect.php
+++ b/core/components/seosuite/src/Model/mysql/SeoSuiteRedirect.php
@@ -2,22 +2,20 @@
 namespace Sterc\SeoSuite\Model\mysql;
 
 use xPDO\xPDO;
-use MODX\Revolution\modContext;
-use MODX\Revolution\modResource;
 
 class SeoSuiteRedirect extends \Sterc\SeoSuite\Model\SeoSuiteRedirect
 {
 
     public static $metaMap = array (
         'package' => 'Sterc\\SeoSuite\\Model\\',
-        'version' => '0.2',
+        'version' => '3.0',
         'table' => 'seosuite_redirect',
-        'extends' => 'xPDOSimpleObject',
-        'tableMeta' =>
+        'extends' => 'xPDO\\Om\\xPDOSimpleObject',
+        'tableMeta' => 
         array (
             'engine' => 'InnoDB',
         ),
-        'fields' =>
+        'fields' => 
         array (
             'context_key' => '',
             'resource_id' => 0,
@@ -26,12 +24,12 @@ class SeoSuiteRedirect extends \Sterc\SeoSuite\Model\SeoSuiteRedirect
             'redirect_type' => '',
             'active' => 1,
             'visits' => 0,
-            'last_visit' => '0000-00-00 00:00:00',
+            'last_visit' => NULL,
             'editedon' => NULL,
         ),
-        'fieldMeta' =>
+        'fieldMeta' => 
         array (
-            'context_key' =>
+            'context_key' => 
             array (
                 'dbtype' => 'varchar',
                 'precision' => '100',
@@ -40,7 +38,7 @@ class SeoSuiteRedirect extends \Sterc\SeoSuite\Model\SeoSuiteRedirect
                 'default' => '',
                 'index' => 'index',
             ),
-            'resource_id' =>
+            'resource_id' => 
             array (
                 'dbtype' => 'integer',
                 'precision' => '10',
@@ -49,7 +47,7 @@ class SeoSuiteRedirect extends \Sterc\SeoSuite\Model\SeoSuiteRedirect
                 'default' => 0,
                 'index' => 'index',
             ),
-            'old_url' =>
+            'old_url' => 
             array (
                 'dbtype' => 'varchar',
                 'precision' => '255',
@@ -58,7 +56,7 @@ class SeoSuiteRedirect extends \Sterc\SeoSuite\Model\SeoSuiteRedirect
                 'default' => '',
                 'index' => 'index',
             ),
-            'new_url' =>
+            'new_url' => 
             array (
                 'dbtype' => 'varchar',
                 'precision' => '255',
@@ -66,7 +64,7 @@ class SeoSuiteRedirect extends \Sterc\SeoSuite\Model\SeoSuiteRedirect
                 'null' => false,
                 'default' => '',
             ),
-            'redirect_type' =>
+            'redirect_type' => 
             array (
                 'dbtype' => 'varchar',
                 'precision' => '75',
@@ -74,7 +72,7 @@ class SeoSuiteRedirect extends \Sterc\SeoSuite\Model\SeoSuiteRedirect
                 'null' => false,
                 'default' => '',
             ),
-            'active' =>
+            'active' => 
             array (
                 'dbtype' => 'tinyint',
                 'precision' => '1',
@@ -84,7 +82,7 @@ class SeoSuiteRedirect extends \Sterc\SeoSuite\Model\SeoSuiteRedirect
                 'default' => 1,
                 'index' => 'index',
             ),
-            'visits' =>
+            'visits' => 
             array (
                 'dbtype' => 'integer',
                 'precision' => '11',
@@ -92,14 +90,13 @@ class SeoSuiteRedirect extends \Sterc\SeoSuite\Model\SeoSuiteRedirect
                 'null' => false,
                 'default' => 0,
             ),
-            'last_visit' =>
+            'last_visit' => 
             array (
                 'dbtype' => 'timestamp',
                 'phptype' => 'timestamp',
                 'null' => true,
-                'default' => '0000-00-00 00:00:00',
             ),
-            'editedon' =>
+            'editedon' => 
             array (
                 'dbtype' => 'timestamp',
                 'phptype' => 'timestamp',
@@ -108,17 +105,17 @@ class SeoSuiteRedirect extends \Sterc\SeoSuite\Model\SeoSuiteRedirect
                 'attributes' => 'ON UPDATE CURRENT_TIMESTAMP',
             ),
         ),
-        'indexes' =>
+        'indexes' => 
         array (
-            'context_key' =>
+            'context_key' => 
             array (
                 'alias' => 'context_key',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'context_key' =>
+                    'context_key' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -126,15 +123,15 @@ class SeoSuiteRedirect extends \Sterc\SeoSuite\Model\SeoSuiteRedirect
                     ),
                 ),
             ),
-            'resource_id' =>
+            'resource_id' => 
             array (
                 'alias' => 'resource_id',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'resource_id' =>
+                    'resource_id' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -142,31 +139,31 @@ class SeoSuiteRedirect extends \Sterc\SeoSuite\Model\SeoSuiteRedirect
                     ),
                 ),
             ),
-            'old_url' =>
+            'old_url' => 
             array (
                 'alias' => 'old_url',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'old_url' =>
+                    'old_url' => 
                     array (
-                        'length' => '',
+                        'length' => '191',
                         'collation' => 'A',
                         'null' => false,
                     ),
                 ),
             ),
-            'active' =>
+            'active' => 
             array (
                 'alias' => 'active',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'active' =>
+                    'active' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -175,19 +172,19 @@ class SeoSuiteRedirect extends \Sterc\SeoSuite\Model\SeoSuiteRedirect
                 ),
             ),
         ),
-        'aggregates' =>
+        'aggregates' => 
         array (
-            'Context' =>
+            'Context' => 
             array (
-                'class' => modContext::class,
+                'class' => 'MODX\\Revolution\\modContext',
                 'local' => 'bundle',
                 'foreign' => 'id',
                 'cardinality' => 'one',
                 'owner' => 'foreign',
             ),
-            'Resource' =>
+            'Resource' => 
             array (
-                'class' => modResource::class,
+                'class' => 'MODX\\Revolution\\modResource',
                 'local' => 'bundle',
                 'foreign' => 'id',
                 'cardinality' => 'one',

--- a/core/components/seosuite/src/Model/mysql/SeoSuiteResource.php
+++ b/core/components/seosuite/src/Model/mysql/SeoSuiteResource.php
@@ -2,21 +2,20 @@
 namespace Sterc\SeoSuite\Model\mysql;
 
 use xPDO\xPDO;
-use MODX\Revolution\modResource;
 
 class SeoSuiteResource extends \Sterc\SeoSuite\Model\SeoSuiteResource
 {
 
     public static $metaMap = array (
         'package' => 'Sterc\\SeoSuite\\Model\\',
-        'version' => '0.2',
+        'version' => '3.0',
         'table' => 'seosuite_resource',
-        'extends' => 'xPDOSimpleObject',
-        'tableMeta' =>
+        'extends' => 'xPDO\\Om\\xPDOSimpleObject',
+        'tableMeta' => 
         array (
             'engine' => 'InnoDB',
         ),
-        'fields' =>
+        'fields' => 
         array (
             'keywords' => '',
             'resource_id' => 0,
@@ -32,16 +31,16 @@ class SeoSuiteResource extends \Sterc\SeoSuite\Model\SeoSuiteResource
             'canonical_uri' => '',
             'editedon' => NULL,
         ),
-        'fieldMeta' =>
+        'fieldMeta' => 
         array (
-            'keywords' =>
+            'keywords' => 
             array (
                 'dbtype' => 'text',
                 'phptype' => 'string',
                 'null' => true,
                 'default' => '',
             ),
-            'resource_id' =>
+            'resource_id' => 
             array (
                 'dbtype' => 'integer',
                 'precision' => '10',
@@ -50,7 +49,7 @@ class SeoSuiteResource extends \Sterc\SeoSuite\Model\SeoSuiteResource
                 'default' => 0,
                 'index' => 'index',
             ),
-            'use_default_meta' =>
+            'use_default_meta' => 
             array (
                 'dbtype' => 'tinyint',
                 'precision' => '1',
@@ -59,19 +58,19 @@ class SeoSuiteResource extends \Sterc\SeoSuite\Model\SeoSuiteResource
                 'null' => false,
                 'default' => 1,
             ),
-            'meta_title' =>
+            'meta_title' => 
             array (
                 'dbtype' => 'mediumtext',
                 'phptype' => 'json',
                 'null' => true,
             ),
-            'meta_description' =>
+            'meta_description' => 
             array (
                 'dbtype' => 'mediumtext',
                 'phptype' => 'json',
                 'null' => true,
             ),
-            'index_type' =>
+            'index_type' => 
             array (
                 'dbtype' => 'tinyint',
                 'precision' => '1',
@@ -81,7 +80,7 @@ class SeoSuiteResource extends \Sterc\SeoSuite\Model\SeoSuiteResource
                 'default' => 1,
                 'index' => 'index',
             ),
-            'follow_type' =>
+            'follow_type' => 
             array (
                 'dbtype' => 'tinyint',
                 'precision' => '1',
@@ -91,7 +90,7 @@ class SeoSuiteResource extends \Sterc\SeoSuite\Model\SeoSuiteResource
                 'default' => 1,
                 'index' => 'index',
             ),
-            'sitemap' =>
+            'sitemap' => 
             array (
                 'dbtype' => 'tinyint',
                 'precision' => '1',
@@ -101,7 +100,7 @@ class SeoSuiteResource extends \Sterc\SeoSuite\Model\SeoSuiteResource
                 'default' => 1,
                 'index' => 'index',
             ),
-            'sitemap_prio' =>
+            'sitemap_prio' => 
             array (
                 'dbtype' => 'varchar',
                 'precision' => '10',
@@ -109,7 +108,7 @@ class SeoSuiteResource extends \Sterc\SeoSuite\Model\SeoSuiteResource
                 'null' => false,
                 'default' => '',
             ),
-            'sitemap_changefreq' =>
+            'sitemap_changefreq' => 
             array (
                 'dbtype' => 'varchar',
                 'precision' => '10',
@@ -117,7 +116,7 @@ class SeoSuiteResource extends \Sterc\SeoSuite\Model\SeoSuiteResource
                 'null' => false,
                 'default' => '',
             ),
-            'canonical' =>
+            'canonical' => 
             array (
                 'dbtype' => 'tinyint',
                 'precision' => '1',
@@ -126,7 +125,7 @@ class SeoSuiteResource extends \Sterc\SeoSuite\Model\SeoSuiteResource
                 'null' => false,
                 'default' => 0,
             ),
-            'canonical_uri' =>
+            'canonical_uri' => 
             array (
                 'dbtype' => 'varchar',
                 'precision' => '255',
@@ -134,7 +133,7 @@ class SeoSuiteResource extends \Sterc\SeoSuite\Model\SeoSuiteResource
                 'null' => false,
                 'default' => '',
             ),
-            'editedon' =>
+            'editedon' => 
             array (
                 'dbtype' => 'timestamp',
                 'phptype' => 'timestamp',
@@ -143,17 +142,17 @@ class SeoSuiteResource extends \Sterc\SeoSuite\Model\SeoSuiteResource
                 'attributes' => 'ON UPDATE CURRENT_TIMESTAMP',
             ),
         ),
-        'indexes' =>
+        'indexes' => 
         array (
-            'resource_id' =>
+            'resource_id' => 
             array (
                 'alias' => 'resource_id',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'resource_id' =>
+                    'resource_id' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -161,15 +160,15 @@ class SeoSuiteResource extends \Sterc\SeoSuite\Model\SeoSuiteResource
                     ),
                 ),
             ),
-            'index_type' =>
+            'index_type' => 
             array (
                 'alias' => 'index_type',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'index_type' =>
+                    'index_type' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -177,15 +176,15 @@ class SeoSuiteResource extends \Sterc\SeoSuite\Model\SeoSuiteResource
                     ),
                 ),
             ),
-            'follow_type' =>
+            'follow_type' => 
             array (
                 'alias' => 'follow_type',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'follow_type' =>
+                    'follow_type' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -193,15 +192,15 @@ class SeoSuiteResource extends \Sterc\SeoSuite\Model\SeoSuiteResource
                     ),
                 ),
             ),
-            'sitemap' =>
+            'sitemap' => 
             array (
                 'alias' => 'sitemap',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'sitemap' =>
+                    'sitemap' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -210,11 +209,11 @@ class SeoSuiteResource extends \Sterc\SeoSuite\Model\SeoSuiteResource
                 ),
             ),
         ),
-        'aggregates' =>
+        'aggregates' => 
         array (
-            'Resource' =>
+            'Resource' => 
             array (
-                'class' => modResource::class,
+                'class' => 'MODX\\Revolution\\modResource',
                 'local' => 'bundle',
                 'foreign' => 'id',
                 'cardinality' => 'one',

--- a/core/components/seosuite/src/Model/mysql/SeoSuiteSocial.php
+++ b/core/components/seosuite/src/Model/mysql/SeoSuiteSocial.php
@@ -2,21 +2,20 @@
 namespace Sterc\SeoSuite\Model\mysql;
 
 use xPDO\xPDO;
-use MODX\Revolution\modResource;
 
 class SeoSuiteSocial extends \Sterc\SeoSuite\Model\SeoSuiteSocial
 {
 
     public static $metaMap = array (
         'package' => 'Sterc\\SeoSuite\\Model\\',
-        'version' => '0.2',
+        'version' => '3.0',
         'table' => 'seosuite_social',
-        'extends' => 'xPDOSimpleObject',
-        'tableMeta' =>
+        'extends' => 'xPDO\\Om\\xPDOSimpleObject',
+        'tableMeta' => 
         array (
             'engine' => 'InnoDB',
         ),
-        'fields' =>
+        'fields' => 
         array (
             'resource_id' => 0,
             'og_title' => '',
@@ -33,9 +32,9 @@ class SeoSuiteSocial extends \Sterc\SeoSuite\Model\SeoSuiteSocial
             'inherit_facebook' => 1,
             'editedon' => NULL,
         ),
-        'fieldMeta' =>
+        'fieldMeta' => 
         array (
-            'resource_id' =>
+            'resource_id' => 
             array (
                 'dbtype' => 'integer',
                 'precision' => '11',
@@ -44,7 +43,7 @@ class SeoSuiteSocial extends \Sterc\SeoSuite\Model\SeoSuiteSocial
                 'default' => 0,
                 'index' => 'index',
             ),
-            'og_title' =>
+            'og_title' => 
             array (
                 'dbtype' => 'varchar',
                 'precision' => '255',
@@ -52,7 +51,7 @@ class SeoSuiteSocial extends \Sterc\SeoSuite\Model\SeoSuiteSocial
                 'null' => false,
                 'default' => '',
             ),
-            'og_description' =>
+            'og_description' => 
             array (
                 'dbtype' => 'varchar',
                 'precision' => '255',
@@ -60,7 +59,7 @@ class SeoSuiteSocial extends \Sterc\SeoSuite\Model\SeoSuiteSocial
                 'null' => false,
                 'default' => '',
             ),
-            'og_image' =>
+            'og_image' => 
             array (
                 'dbtype' => 'varchar',
                 'precision' => '255',
@@ -68,7 +67,7 @@ class SeoSuiteSocial extends \Sterc\SeoSuite\Model\SeoSuiteSocial
                 'null' => false,
                 'default' => '',
             ),
-            'og_image_alt' =>
+            'og_image_alt' => 
             array (
                 'dbtype' => 'varchar',
                 'precision' => '255',
@@ -76,7 +75,7 @@ class SeoSuiteSocial extends \Sterc\SeoSuite\Model\SeoSuiteSocial
                 'null' => false,
                 'default' => '',
             ),
-            'og_type' =>
+            'og_type' => 
             array (
                 'dbtype' => 'varchar',
                 'precision' => '40',
@@ -84,7 +83,7 @@ class SeoSuiteSocial extends \Sterc\SeoSuite\Model\SeoSuiteSocial
                 'null' => false,
                 'default' => '',
             ),
-            'twitter_title' =>
+            'twitter_title' => 
             array (
                 'dbtype' => 'varchar',
                 'precision' => '255',
@@ -92,7 +91,7 @@ class SeoSuiteSocial extends \Sterc\SeoSuite\Model\SeoSuiteSocial
                 'null' => false,
                 'default' => '',
             ),
-            'twitter_description' =>
+            'twitter_description' => 
             array (
                 'dbtype' => 'varchar',
                 'precision' => '255',
@@ -100,7 +99,7 @@ class SeoSuiteSocial extends \Sterc\SeoSuite\Model\SeoSuiteSocial
                 'null' => false,
                 'default' => '',
             ),
-            'twitter_image' =>
+            'twitter_image' => 
             array (
                 'dbtype' => 'varchar',
                 'precision' => '255',
@@ -108,7 +107,7 @@ class SeoSuiteSocial extends \Sterc\SeoSuite\Model\SeoSuiteSocial
                 'null' => false,
                 'default' => '',
             ),
-            'twitter_image_alt' =>
+            'twitter_image_alt' => 
             array (
                 'dbtype' => 'varchar',
                 'precision' => '255',
@@ -116,7 +115,7 @@ class SeoSuiteSocial extends \Sterc\SeoSuite\Model\SeoSuiteSocial
                 'null' => false,
                 'default' => '',
             ),
-            'twitter_creator_id' =>
+            'twitter_creator_id' => 
             array (
                 'dbtype' => 'varchar',
                 'precision' => '255',
@@ -124,7 +123,7 @@ class SeoSuiteSocial extends \Sterc\SeoSuite\Model\SeoSuiteSocial
                 'null' => false,
                 'default' => '',
             ),
-            'twitter_card' =>
+            'twitter_card' => 
             array (
                 'dbtype' => 'varchar',
                 'precision' => '40',
@@ -132,7 +131,7 @@ class SeoSuiteSocial extends \Sterc\SeoSuite\Model\SeoSuiteSocial
                 'null' => false,
                 'default' => '',
             ),
-            'inherit_facebook' =>
+            'inherit_facebook' => 
             array (
                 'dbtype' => 'int',
                 'precision' => '1',
@@ -140,7 +139,7 @@ class SeoSuiteSocial extends \Sterc\SeoSuite\Model\SeoSuiteSocial
                 'null' => true,
                 'default' => 1,
             ),
-            'editedon' =>
+            'editedon' => 
             array (
                 'dbtype' => 'timestamp',
                 'phptype' => 'timestamp',
@@ -149,17 +148,17 @@ class SeoSuiteSocial extends \Sterc\SeoSuite\Model\SeoSuiteSocial
                 'attributes' => 'ON UPDATE CURRENT_TIMESTAMP',
             ),
         ),
-        'indexes' =>
+        'indexes' => 
         array (
-            'resource_id' =>
+            'resource_id' => 
             array (
                 'alias' => 'resource_id',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'resource_id' =>
+                    'resource_id' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -168,11 +167,11 @@ class SeoSuiteSocial extends \Sterc\SeoSuite\Model\SeoSuiteSocial
                 ),
             ),
         ),
-        'aggregates' =>
+        'aggregates' => 
         array (
-            'Resource' =>
+            'Resource' => 
             array (
-                'class' => modResource::class,
+                'class' => 'MODX\\Revolution\\modResource',
                 'local' => 'bundle',
                 'foreign' => 'id',
                 'cardinality' => 'one',

--- a/core/components/seosuite/src/Model/mysql/SeoSuiteUrl.php
+++ b/core/components/seosuite/src/Model/mysql/SeoSuiteUrl.php
@@ -2,32 +2,31 @@
 namespace Sterc\SeoSuite\Model\mysql;
 
 use xPDO\xPDO;
-use MODX\Revolution\modContext;
 
 class SeoSuiteUrl extends \Sterc\SeoSuite\Model\SeoSuiteUrl
 {
 
     public static $metaMap = array (
         'package' => 'Sterc\\SeoSuite\\Model\\',
-        'version' => '0.2',
+        'version' => '3.0',
         'table' => 'seosuite_url',
-        'extends' => 'xPDOSimpleObject',
-        'tableMeta' =>
+        'extends' => 'xPDO\\Om\\xPDOSimpleObject',
+        'tableMeta' => 
         array (
             'engine' => 'InnoDB',
         ),
-        'fields' =>
+        'fields' => 
         array (
             'context_key' => '',
             'url' => '',
             'suggestions' => NULL,
             'visits' => 0,
-            'last_visit' => '0000-00-00 00:00:00',
+            'last_visit' => NULL,
             'createdon' => 'CURRENT_TIMESTAMP',
         ),
-        'fieldMeta' =>
+        'fieldMeta' => 
         array (
-            'context_key' =>
+            'context_key' => 
             array (
                 'dbtype' => 'varchar',
                 'precision' => '100',
@@ -36,7 +35,7 @@ class SeoSuiteUrl extends \Sterc\SeoSuite\Model\SeoSuiteUrl
                 'default' => '',
                 'index' => 'index',
             ),
-            'url' =>
+            'url' => 
             array (
                 'dbtype' => 'varchar',
                 'precision' => '2000',
@@ -45,13 +44,13 @@ class SeoSuiteUrl extends \Sterc\SeoSuite\Model\SeoSuiteUrl
                 'default' => '',
                 'index' => 'index',
             ),
-            'suggestions' =>
+            'suggestions' => 
             array (
                 'dbtype' => 'text',
                 'phptype' => 'json',
                 'null' => true,
             ),
-            'visits' =>
+            'visits' => 
             array (
                 'dbtype' => 'integer',
                 'precision' => '11',
@@ -59,14 +58,13 @@ class SeoSuiteUrl extends \Sterc\SeoSuite\Model\SeoSuiteUrl
                 'null' => false,
                 'default' => 0,
             ),
-            'last_visit' =>
+            'last_visit' => 
             array (
                 'dbtype' => 'timestamp',
                 'phptype' => 'timestamp',
                 'null' => true,
-                'default' => '0000-00-00 00:00:00',
             ),
-            'createdon' =>
+            'createdon' => 
             array (
                 'dbtype' => 'timestamp',
                 'phptype' => 'timestamp',
@@ -74,17 +72,17 @@ class SeoSuiteUrl extends \Sterc\SeoSuite\Model\SeoSuiteUrl
                 'default' => 'CURRENT_TIMESTAMP',
             ),
         ),
-        'indexes' =>
+        'indexes' => 
         array (
-            'context_key' =>
+            'context_key' => 
             array (
                 'alias' => 'context_key',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'context_key' =>
+                    'context_key' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -92,28 +90,28 @@ class SeoSuiteUrl extends \Sterc\SeoSuite\Model\SeoSuiteUrl
                     ),
                 ),
             ),
-            'url' =>
+            'url' => 
             array (
                 'alias' => 'url',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'url' =>
+                    'url' => 
                     array (
-                        'length' => '',
+                        'length' => '191',
                         'collation' => 'A',
                         'null' => false,
                     ),
                 ),
             ),
         ),
-        'aggregates' =>
+        'aggregates' => 
         array (
-            'Context' =>
+            'Context' => 
             array (
-                'class' => modContext::class,
+                'class' => 'MODX\\Revolution\\modContext',
                 'local' => 'bundle',
                 'foreign' => 'id',
                 'cardinality' => 'one',


### PR DESCRIPTION
This PR

- deletes the default value "0000-00-00 00:00:00" for timestamp fields -> Creates error "Invalid default value" if SQL Mode `NO_ZERO_DATE` is enabled in the database configuration.
- changes the length of certain indexes -> Creates error "Index column size too large. The maximum column size is 767 bytes." if a utf8mb4 charset is used.
- adjusts some other issues in the schema (like the `<model>` version and the `<object>` base classes).
- moves the schema file to the folder `core/components/seosuite/schema`. (I believe that's where GPM expects it to be.)