### PR TITLE
Fix return value of the "setupoptions" resolver 

### DIFF
--- a/_build/scripts/setupoptions.resolver.php
+++ b/_build/scripts/setupoptions.resolver.php
@@ -99,6 +99,8 @@ class SeoSuiteSetupOptionsResolver
             $migrationSetting->set('value', true);
             $migrationSetting->save();
         }
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
When the extra is newly installed, the console outputs this error message
```
xPDOScriptVehicle execution failed: ( .../xPDO/Transport/xPDOScriptVehicle/9eaeb38cc309241f5d77a7aec117d2c3.setupoptions.resolver.script)
```
because the resolver doesn't return `true` at the end of the process.