### PR TITLE
Fix fatal error if suggestion property can't be decoded

### DIFF
--- a/core/components/seosuite/src/Processors/Mgr/Urls/Suggestions/GetList.php
+++ b/core/components/seosuite/src/Processors/Mgr/Urls/Suggestions/GetList.php
@@ -57,7 +57,7 @@ class GetList extends GetListProcessor
      */
     public function initialize()
     {
-        $suggestions = json_decode($this->getProperty('suggestions'), true);
+        $suggestions = json_decode($this->getProperty('suggestions'), true) ? json_decode($this->getProperty('suggestions'), true) : [];
 
         if ($suggestions && is_array($suggestions)) {
             arsort($suggestions);


### PR DESCRIPTION
PHP Fatal error:  Uncaught TypeError: arsort(): Argument #1 ($array) must be of type array, null given