### PR TITLE
Fix permissions are added wrong to the access_policies table

### DIFF
--- a/_build/scripts/permissions.resolver.php
+++ b/_build/scripts/permissions.resolver.php
@@ -51,26 +51,26 @@ if ($transport->xpdo) {
                         }
                     }
                 }
-            }
 
-            foreach ($modx->getCollection(modAccessPolicy::class) as $accessPolicy) {
-                $data = $accessPolicy->get('data');
-
-                foreach ($permissions as $permission) {
-                    if (isset($permission['policies'])) {
-                        if (in_array($accessPolicy->get('name'), $permission['policies'], true)) {
-                            $data[$permission['name']] = true;
+                foreach ($modx->getCollection(modAccessPolicy::class, ['template' => $accessTemplate->get('id')]) as $accessPolicy) {
+                    $data = $accessPolicy->get('data');
+    
+                    foreach ($permissions as $permission) {
+                        if (isset($permission['policies'])) {
+                            if (in_array($accessPolicy->get('name'), $permission['policies'], true)) {
+                                $data[$permission['name']] = true;
+                            } else {
+                                $data[$permission['name']] = false;
+                            }
                         } else {
-                            $data[$permission['name']] = false;
+                            $data[$permission['name']] = true;
                         }
-                    } else {
-                        $data[$permission['name']] = true;
                     }
+    
+                    $accessPolicy->set('data', $data);
+    
+                    $accessPolicy->save();
                 }
-
-                $accessPolicy->set('data', $data);
-
-                $accessPolicy->save();
             }
 
             $success = true;


### PR DESCRIPTION
Move the getCollection loop of modAccessPolicy into the getCollection loop of the modAccessPolicyTemplate and restrict the getCollection loop of modAccessPolicy with the access policy template.

#141 

The same fix has to go into the according FormIt resolver too.